### PR TITLE
snapcraft.yaml: patch sdlpop to not install desktop file

### DIFF
--- a/patches/install.patch
+++ b/patches/install.patch
@@ -1,0 +1,10 @@
+diff --git a/src/install.sh b/src/install.sh
+index dc0e625..81e17fc 100755
+--- a/src/install.sh
++++ b/src/install.sh
+@@ -3,5 +3,3 @@
+ cd ..
+ # Since we don't copy the executable or the data folder anywhere, the desktop file has to be updated to contain the actual paths.
+ sed -e 's|$ROOT|'"$PWD"'|' src/SDLPoP.desktop.template > src/SDLPoP.desktop
+-cp src/SDLPoP.desktop /usr/share/applications/
+-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ apps:
 
 parts:
   sdlpop:
-    after: [desktop-glib-only]
+    after: [desktop-glib-only, patches]
     plugin: make
     source: https://github.com/NagyD/SDLPoP.git
     source-type: git
@@ -35,7 +35,9 @@ parts:
       - libgl1-mesa-dri
       - libgl1-mesa-glx
       - libglu1-mesa
-    override-build: |
+    override-pull: |
+      snapcraftctl pull
+
       last_committed_tag="$(git describe --tags --abbrev=0)"
       last_released_tag="$(snap info sdlpop | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
@@ -44,5 +46,13 @@ parts:
         git fetch
         git checkout "${last_committed_tag}"
       fi
+
+      git apply $SNAPCRAFT_STAGE/install.patch
+    override-build: |
       snapcraftctl build
       cp -a * $SNAPCRAFT_PART_INSTALL/
+
+  patches:
+    plugin: dump
+    source: patches
+    prime: [-*]


### PR DESCRIPTION
sdlpop attempts to install its desktop file into `/usr/share/applications`, which of course cannot happen without sudo, and if it does happen is both useless and bad.