### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,6 @@ parts:
     source: https://github.com/NagyD/SDLPoP.git
     source-type: git
     source-subdir: src
-    source-tag: "v1.18.1"
     build-packages:
       - libsdl2-image-dev
     stage-packages:


### PR DESCRIPTION
We're currently building only from the stable release, but we really should build from master given we have all the necessary bits to detect version number.