### PR TITLE
Add Joystick support and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# gitginore template for creating Snap packages
+# website: https://snapcraft.io/
+
+parts/
+prime/
+stage/
+*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,34 @@
+
 language: bash
-os: linux
-sudo: enabled
+dist: xenial
+
 env:
   global:
     - LC_ALL: C.UTF-8
     - LANG: C.UTF-8
+    - SNAPCRAFT_ENABLE_SILENT_REPORT: y
+    - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
 
-install:
+addons:
+  snaps:
+    - name: snapcraft
+      channel: stable
+      classic: true
+    - name: http
+    - name: transfer
+    - name: lxd
+      channel: stable
+
+script:
   - sudo apt update
-  - sudo apt install -y snapd
-  - sudo snap install lxd --channel 3.0/stable
-  - sudo snap install snapcraft --candidate --classic
+  - sudo /snap/bin/lxd.migrate -yes
   - sudo /snap/bin/lxd waitready
   - sudo /snap/bin/lxd init --auto
   - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
-script:
-  - export PATH=/snap/bin:$PATH
-  - sudo snapcraft cleanbuild
-  - sudo cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - sudo snapcraft --use-lxd
 after_success:
-  - sudo snap install transfer
-  - timeout 180 sudo /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - timeout 180 /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
 after_failure:
   - sudo journalctl -u snapd
-  - sudo snap install http
-  - /snap/bin/http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
+  - http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,4 @@
+base: core
 name: sdlpop
 summary: Open Source Prince of Persia port.
 description: |
@@ -61,6 +62,7 @@ parts:
       - libgl1-mesa-dri
       - libgl1-mesa-glx
       - libglu1-mesa
+      - libsdl2-image-2.0-0
     override-pull: |
       snapcraftctl pull
 
@@ -82,3 +84,12 @@ parts:
     plugin: dump
     source: patches
     prime: [-*]
+
+  desktop-glib-only:
+    build-packages:
+    - libglib2.0-dev
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: glib-only
+    stage-packages:
+    - libglib2.0-bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 base: core18
 name: sdlpop
+title: SDLPoP
 summary: Open Source Prince of Persia port.
 description: |
   An open-source port of the 1989 "Prince of Persia" video game, based on the disassembly of the 
@@ -31,6 +32,7 @@ description: |
 
   This snap is maintained by the Snapcrafters community, and is not necessarily
   endorsed or officially maintained by the upstream developers.
+license: "GPL-3.0"
 adopt-info: sdlpop
 
 grade: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-base: core
+base: core18
 name: sdlpop
 summary: Open Source Prince of Persia port.
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,35 @@
 name: sdlpop
-summary: SDLPoP
+summary: Open Source Prince of Persia port.
 description: |
-  An open-source port of Prince of Persia, based on the disassembly of the 
+  An open-source port of the 1989 "Prince of Persia" video game, based on the disassembly of the 
   DOS version.
+
+  Controlling the kid:
+
+    * left: turn or run left
+    * right: turn or run right
+    * up: jump or climb up
+    * down: crouch or climb down
+    * shift: pick up things
+    * shift+left/right: careful step
+    * home or up+left: jump left
+    * page up or up+right: jump right
+
+  You can also use the numeric keypad.
+
+  Gamepad equivalents:
+
+  * D-Pad: arrows
+  * Joystick: left/right
+  * A: down
+  * Y: up
+  * X or triggers: shift
+  * Start or Back: display in-game menu
+
+  You can find more information and controls in the SDLPoP readme: <https://github.com/NagyD/SDLPoP/tree/master/doc>.
+
+  This snap is maintained by the Snapcrafters community, and is not necessarily
+  endorsed or officially maintained by the upstream developers.
 adopt-info: sdlpop
 
 grade: stable
@@ -19,6 +46,7 @@ apps:
       - opengl
       - pulseaudio
       - screen-inhibit-control
+      - joystick
 
 parts:
   sdlpop:


### PR DESCRIPTION
This PR

* Adds Joystick support
* Switches to `base: core18`
* Adds the game controls to the description of the snap
* Adds a more useful `summary` as asked by upstream: https://forum.princed.org/viewtopic.php?t=4189
* Adds the `license` and `title` metadata
* Fixes `.travis.yml`

After this PR is merged, I'll ask for a joystick auto-connection and contact upstream to see if they want to maintain this further.