### PR TITLE
Enable persistent settings

### DIFF
--- a/scripts/wrapper
+++ b/scripts/wrapper
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Make sure SDLPoP reads and writes files from $SNAP_USER_COMMON instead of PWD.
+cd $SNAP_USER_COMMON
+
+# Make sure SDLPoP.cfg file exists, otherwise SDLPoP tries to create it in the
+# same directory as the binary. Don't touch it if it exists, because SDLPoP
+# uses the timestamp to reset SDLPoP.cfg when SDLPoP.ini changes.
+if [ ! -f SDLPoP.cfg ]; then
+    touch SDLPoP.cfg
+fi
+
+# Run the game
+exec $SNAP/bin/desktop-launch $SNAP/prince  "${@:1}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,12 +40,11 @@ confinement: strict
 
 apps:
   sdlpop:
-    command: desktop-launch $SNAP/prince
+    command: wrapper
     plugs:
       - unity7
       - network
       - network-bind
-      - home
       - opengl
       - pulseaudio
       - screen-inhibit-control
@@ -86,6 +85,12 @@ parts:
     plugin: dump
     source: patches
     prime: [-*]
+
+  scripts:
+    plugin: dump
+    source: scripts
+    organize:
+      'prepare': bin/
 
   desktop-glib-only:
     build-packages:


### PR DESCRIPTION
Settings were not saved between game launches because SDLPoP tried to create the settings file in the (read only) parent directory of the binary.

This PR enables persistent settings by changing PWD to $SNAP_USER_COMMON and creating an empty settings file if it doesn't exist. This also removes the need for SDLPoP to access home since it writes everything to PWD. As an added bonus; saving levels and creating screenshots now also works when PWD is not writeable.