### PR TITLE
Port to `gnome-3-28` extension and add cleanup part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # gitginore template for creating Snap packages
 # website: https://snapcraft.io/
 
+squashfs-root
+
 parts/
 prime/
 stage/

--- a/scripts/wrapper
+++ b/scripts/wrapper
@@ -10,5 +10,5 @@ if [ ! -f SDLPoP.cfg ]; then
     touch SDLPoP.cfg
 fi
 
-# Run the game
-exec $SNAP/bin/desktop-launch $SNAP/prince  "${@:1}"
+# run the rest of the command chain
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,3 @@
-base: core18
 name: sdlpop
 title: SDLPoP
 summary: Open Source Prince of Persia port.
@@ -35,25 +34,28 @@ description: |
   endorsed or officially maintained by the upstream developers.
 license: "GPL-3.0"
 adopt-info: sdlpop
-
 grade: stable
+
+base: core18
 confinement: strict
 
 apps:
   sdlpop:
-    command: wrapper
+    extensions:
+      - gnome-3-28
+    command: prince
+    command-chain:
+      - bin/wrapper
     plugs:
-      - unity7
-      - network
-      - network-bind
       - opengl
-      - pulseaudio
+      - audio-playback
+      - pulseaudio      # Only here to support older snapd versions.
       - screen-inhibit-control
       - joystick
 
 parts:
   sdlpop:
-    after: [desktop-glib-only, patches]
+    after: [patches]
     plugin: make
     source: https://github.com/NagyD/SDLPoP.git
     source-type: git
@@ -91,13 +93,4 @@ parts:
     plugin: dump
     source: scripts
     organize:
-      'prepare': bin/
-
-  desktop-glib-only:
-    build-packages:
-    - libglib2.0-dev
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: glib-only
-    stage-packages:
-    - libglib2.0-bin
+      'wrapper': bin/wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,3 +94,18 @@ parts:
     source: scripts
     organize:
       'wrapper': bin/wrapper
+
+  cleanup:
+      after:  # Make this part run last; list all your other parts here
+        - sdlpop
+        - patches
+        - scripts
+      plugin: nil
+      build-snaps:  # List all content-snaps and base snaps you're using here
+        - core18
+        - gnome-3-28-1804
+      override-prime: |
+        set -eux
+        for snap in "core18" "gnome-3-28-1804"; do  # List all content-snaps and base snaps you're using here
+          cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+        done


### PR DESCRIPTION
This makes the snapcraft.yaml a lot cleaner and reduces the size of the snap from 35 MB -> 1 MB!